### PR TITLE
Add animated slide-in and fix "modal bottom sheet" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-_[Demo and API Docs](http://collaborne.github.io/paper-bottom-sheet)_
+_[Demo and API Docs](http://emanguy.github.io/paper-bottom-sheet)_
 
 
 paper-bottom-sheet [![Bower version](https://badge.fury.io/bo/paper-bottom-sheet.svg)](http://badge.fury.io/bo/paper-bottom-sheet) [![Travis state](https://travis-ci.org/Collaborne/paper-bottom-sheet.svg?branch=master)](https://travis-ci.org/Collaborne/paper-bottom-sheet)

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "paper-item": "PolymerElements/paper-item#^1.0.0",
     "paper-dialog": "PolymerElements/paper-dialog#^1.0.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
-    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+    "neon-animation": "PolymerElements/neon-animation#^1.2.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,12 +9,14 @@
 
 	<body>
 		<template is="dom-bind">
-			<paper-bottom-sheet id="sheet">
+			<paper-bottom-sheet slide="{{sliding}}" id="sheet">
 				<paper-bottom-sheet-item text="Star" icon="icons:star-border" on-tap="tapStar"></paper-bottom-sheet-item>
 				<paper-bottom-sheet-item text="Delete" icon="icons:delete" warning on-tap="tapDelete"></paper-bottom-sheet-item>
 			</paper-bottom-sheet>
 
 			<button type="button" on-tap="openSheet">Open</button>
+			<input type="checkbox"  on-tap="toggleSliding">Slide in</input>
+			
 		</template>
 
 		<script>
@@ -27,6 +29,10 @@
 				this.$.sheet.close();
 
 				alert("Stared");
+			}
+
+			scope.toggleSliding = function() {
+				this.sliding = !this.sliding;
 			}
 
 			scope.tapDelete = function() {

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,13 +9,14 @@
 
 	<body>
 		<template is="dom-bind">
-			<paper-bottom-sheet slide="{{sliding}}" id="sheet">
+			<paper-bottom-sheet slide="{{sliding}}" modal="{{modalSheet}}" id="sheet">
 				<paper-bottom-sheet-item text="Star" icon="icons:star-border" on-tap="tapStar"></paper-bottom-sheet-item>
 				<paper-bottom-sheet-item text="Delete" icon="icons:delete" warning on-tap="tapDelete"></paper-bottom-sheet-item>
 			</paper-bottom-sheet>
 
 			<button type="button" on-tap="openSheet">Open</button>
 			<input type="checkbox"  on-tap="toggleSliding">Slide in</input>
+			<input type="checkbox" on-tap="toggleModal">Modal bottom sheet</input>
 			
 		</template>
 
@@ -28,11 +29,15 @@
 			scope.tapStar = function() {
 				this.$.sheet.close();
 
-				alert("Stared");
+				alert("Starred");
 			}
 
 			scope.toggleSliding = function() {
 				this.sliding = !this.sliding;
+			}
+
+			scope.toggleModal = function() {
+				this.modalSheet = !this.modalSheet;
 			}
 
 			scope.tapDelete = function() {

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -43,7 +43,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" with-backdrop modal="[[modal]]" on-neon-animation-finish="_attemptRemoval">
 			<div class="content">
 				<content id="items"></content>
-				<paper-bottom-sheet-item hidden$="[[modal]]"id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
+				<paper-bottom-sheet-item hidden$="[[!modal]]" id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
 			</div>
 		</paper-dialog>
 	</template>
@@ -71,9 +71,15 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			},
 
 			/**
-			 * True if the bottom sheet acts like a modal dialog (e.g. can't be closed by clicking outside)
+			 * True if the bottom sheet acts like a modal dialog (e.g. can't be closed by clicking outside).
+			 * Note that the "cancel" option will disappear if the dialog is not modal, as the "cancel" option
+			 * will be the user's only method of exit when the bottom sheet is modal.
 			 */
-			modal: Boolean,
+			modal: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			},
 
 			/**
 			 * True if the bottom sheet should slide in from the bottom on entry

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -3,6 +3,8 @@
 <link rel="import" href="../paper-dialog/paper-dialog.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../iron-selector/iron-selectable.html">
+<link rel="import" href="../neon-animation/animations/slide-from-bottom-animation.html">
+<link rel="import" href="../neon-animation/animations/slide-down-animation.html">
 <link rel="import" href="paper-bottom-sheet-item.html">
 
 <!--
@@ -38,7 +40,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		</style>
 
-		<paper-dialog id="dialog" class="dialog" with-backdrop model="[[model]]">
+		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" with-backdrop model="[[model]]" on-neon-animation-finish="_attemptRemoval">
 			<div class="content">
 				<content id="items"></content>
 				<paper-bottom-sheet-item id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
@@ -71,10 +73,32 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			/**
 			 * True if the bottom sheet acts like a modal dialog (e.g. can't be closed by clicking outside)
 			 */
-			model: Boolean
+			model: Boolean,
+
+			/**
+			 * True if the bottom sheet should slide in from the bottom on entry
+			 */
+			slide: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			},
+
+			/**
+			 * The animation config supplied to the included paper-dialog. Will be empty unless "slide"
+			 * is set.
+			 */
+			_dialogAnimationConfig: {
+				type: Object,
+				computed: '_animationConfig(slide)'
+			},
 		},
 
 		// Public methods
+
+		/**
+		 * Open the bottom sheet and append it to the DOM.
+		 */
 		open: function() {
 			Polymer.dom(document.body).appendChild(this);
 
@@ -83,10 +107,51 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
                                 this.$.dialog.open();
                         }.bind(this), 1);
 		},
+		/**
+		 * Close the bottom sheet and remove it from the DOM.
+		 */
 		close: function() {
 			this.$.dialog.close();
-			// Remove the dialog from the DOM
-			Polymer.dom(this.parentNode).removeChild(this);
+
+			// Remove the dialog from the DOM if there is no animation
+			if (!this.slide)
+			{ 
+				Polymer.dom(this.parentNode).removeChild(this); 
+			}
+		},
+
+		// Private methods
+		// Computed property function- changes the animation config of the dialog based on presence of "slide" attr
+		_animationConfig: function(slide)
+		{
+			console.log("config changed");
+			if (slide == true)
+			{
+				return {
+					'entry': {
+						'name': "slide-from-bottom-animation",
+						'node': this.$.dialog
+					},
+					'exit': {
+						'name': "slide-down-animation",
+						'node': this.$.dialog
+					}
+				};
+			}
+			else
+			{
+				return {};
+			}
+		},
+
+		// Runs when the dialog animation completes. Will remove this from the DOM if the dialog was just closed.
+		_attemptRemoval: function()
+		{
+			// Remove this element from DOM if there is an animation and the dialog just closed
+			if (this.slide && !this.$.dialog.opened)
+			{
+				Polymer.dom(this.parentNode).removeChild(this);
+			}
 		}
 	});
 

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -40,10 +40,10 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		</style>
 
-		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" with-backdrop model="[[model]]" on-neon-animation-finish="_attemptRemoval">
+		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" with-backdrop modal="[[modal]]" on-neon-animation-finish="_attemptRemoval">
 			<div class="content">
 				<content id="items"></content>
-				<paper-bottom-sheet-item id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
+				<paper-bottom-sheet-item hidden$="[[modal]]"id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
 			</div>
 		</paper-dialog>
 	</template>
@@ -73,7 +73,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			/**
 			 * True if the bottom sheet acts like a modal dialog (e.g. can't be closed by clicking outside)
 			 */
-			model: Boolean,
+			modal: Boolean,
 
 			/**
 			 * True if the bottom sheet should slide in from the bottom on entry

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -40,7 +40,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		</style>
 
-		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" with-backdrop modal="[[modal]]" on-neon-animation-finish="_attemptRemoval">
+		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" with-backdrop modal="[[modal]]" on-iron-overlay-closed="_attemptRemoval">
 			<div class="content">
 				<content id="items"></content>
 				<paper-bottom-sheet-item hidden$="[[!modal]]" id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
@@ -122,7 +122,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			// Remove the dialog from the DOM if there is no animation
 			if (!this.slide)
 			{ 
-				Polymer.dom(this.parentNode).removeChild(this); 
+				_attemptRemoval();
 			}
 		},
 
@@ -130,7 +130,6 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 		// Computed property function- changes the animation config of the dialog based on presence of "slide" attr
 		_animationConfig: function(slide)
 		{
-			console.log("config changed");
 			if (slide == true)
 			{
 				return {
@@ -150,14 +149,11 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		},
 
-		// Runs when the dialog animation completes. Will remove this from the DOM if the dialog was just closed.
+		// Runs when the dialog is closed. Will remove this from the DOM
 		_attemptRemoval: function()
 		{
 			// Remove this element from DOM if there is an animation and the dialog just closed
-			if (this.slide && !this.$.dialog.opened)
-			{
-				Polymer.dom(this.parentNode).removeChild(this);
-			}
+			Polymer.dom(this.parentNode).removeChild(this);
 		}
 	});
 


### PR DESCRIPTION
Fixes:
- Some spelling
- Issue where clicking an option on the bottom sheet, clicking outside the bottom sheet, or pressing the escape key would prevent the intended functionality of removing the paper-bottom-sheet from the DOM.
- Change of "model" to "modal" which fixes modal bottom sheet behavior

Additions:
- "slide" attribute which causes the bottom sheet to animate its entrance from the bottom of the screen
- Add documentation for open() and close() functions
- Add checkbox toggles for the "slide" and "modal" attributes in the demo

Behavioral changes:
- Setting the "modal" attribute will reveal the "cancel" option as the last option in the bottom sheet. When the paper dialog is not modal, the "cancel" option is hidden. In the non-modal case, the cancel option is redundant due to the fact that the user can click or tap outside the bottom sheet to hide/cancel it.

EDIT: demo from my repository at http://emanguy.github.io/paper-bottom-sheet.

EDIT 2: you'll have to update your readme so it doesn't point to mine when you merge
