### PR TITLE
No cancel behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 before_install:
 - "if [ -d node_modules ] && [ x$(cat node_modules/.last-node-version 2>/dev/null) != x$(node -e 'console.log(process.version)') ]; then npm rebuild && node -e 'console.log(process.version)' > node_modules/.last-node-version; fi"
 before_script:
-- npm install web-component-tester bower@1.7.9 polylint
+- npm install web-component-tester bower@1.8.4 polylint
 - $(npm bin)/bower install
 - $(npm bin)/polylint --no-recursion
 script:

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -45,7 +45,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		</style>
 
-		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" modal="[[modal]]" with-backdrop="[[withBackdrop]]" on-iron-overlay-closed="_attemptRemoval" auto-fit-on-attach>
+		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" no-cancel-on-esc-key="noCancelOnEscKey" no-cancel-on-outside-click="[[noCancelOnOutsideClick]]" modal="[[modal]]" with-backdrop="[[withBackdrop]]" on-iron-overlay-closed="_attemptRemoval" auto-fit-on-attach>
 			<div class="content">
 				<slot id="items"></slot>
 				<paper-bottom-sheet-item hidden$="[[!modal]]" id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
@@ -103,6 +103,22 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 				type: Boolean,
 				value: true,
 				reflectToAttribute: true
+			},
+
+			/**
+			* Set to true to disable canceling the overlay with the ESC key.
+			*/
+			noCancelOnEscKey: {
+				type: Boolean, 
+				value: false
+			},
+
+			/**
+			* Set to true to disable canceling the overlay by clicking outside it.
+			*/
+			noCancelOnOutsideClick: {
+				type: Boolean, 
+				value: false
 			},
 
 			/**

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -45,7 +45,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		</style>
 
-		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" no-cancel-on-esc-key="noCancelOnEscKey" no-cancel-on-outside-click="[[noCancelOnOutsideClick]]" modal="[[modal]]" with-backdrop="[[withBackdrop]]" on-iron-overlay-closed="_attemptRemoval" auto-fit-on-attach>
+		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" no-cancel-on-esc-key="[[noCancelOnEscKey]]" no-cancel-on-outside-click="[[noCancelOnOutsideClick]]" modal="[[modal]]" with-backdrop="[[withBackdrop]]" on-iron-overlay-closed="_attemptRemoval" auto-fit-on-attach>
 			<div class="content">
 				<slot id="items"></slot>
 				<paper-bottom-sheet-item hidden$="[[!modal]]" id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>

--- a/paper-bottom-sheet.html
+++ b/paper-bottom-sheet.html
@@ -45,7 +45,7 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 			}
 		</style>
 
-		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" modal="[[modal]]" with-backdrop="[[withBackdrop]]" on-iron-overlay-closed="_attemptRemoval" auto-fit-on-attach>
+		<paper-dialog id="dialog" class="dialog" animation-config="{{_dialogAnimationConfig}}" no-cancel-on-esc-key="noCancelOnEscKey" no-cancel-on-outside-click="[[noCancelOnOutsideClick]]" modal="[[modal]]" with-backdrop="[[withBackdrop]]" on-iron-overlay-closed="_attemptRemoval" auto-fit-on-attach>
 			<div class="content">
 				<slot id="items"></slot>
 				<paper-bottom-sheet-item hidden$="[[!modal]]" id="cancel" text="[[cancelText]]" icon="icons:close" on-tap="close"></paper-bottom-sheet-item>
@@ -104,6 +104,16 @@ A material design modal [bottom sheet](https://www.google.com/design/spec/compon
 				value: true,
 				reflectToAttribute: true
 			},
+
+			/**
+			* Set to true to disable canceling the overlay with the ESC key.
+			*/
+			noCancelOnEscKey: {type: Boolean, value: false},
+
+			/**
+			* Set to true to disable canceling the overlay by clicking outside it.
+			*/
+			noCancelOnOutsideClick: {type: Boolean, value: false},
 
 			/**
 			 * The animation config supplied to the included paper-dialog. Will be empty unless "slide"


### PR DESCRIPTION
This enables the use of `no-cancel-on-outside-click` and `no-cancel-on-esc-key`.

We use this for a non-modal bottom-sheet that deals with a multiple selection. Otherwise selecting another value will cause the sheet to close.